### PR TITLE
Reintegrate rag

### DIFF
--- a/docker-image/src/FAISS_db_generation.py
+++ b/docker-image/src/FAISS_db_generation.py
@@ -1,12 +1,17 @@
-import os
-import sys
+import os, sys
+import pandas as pd
+import openai
+import glob
 from dotenv import load_dotenv, find_dotenv
 from langchain_community.vectorstores import FAISS
 from langchain_openai import OpenAIEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
-import pandas as pd
-import openai
+from langchain_community.document_loaders import (
+    PyPDFLoader,
+    TextLoader,
+    UnstructuredWordDocumentLoader,
+    UnstructuredPowerPointLoader
+)
 
 # Load environment variables from .env file
 load_dotenv(find_dotenv())
@@ -17,14 +22,32 @@ def create_database(course_dir):
         print(f"The provided path is not a valid directory: {course_dir}")
         sys.exit(1)
 
-    # PDF Loading and Text Extraction
-    # TODO Load non-pdf content as well
-    loader = DirectoryLoader(course_dir, glob="**/*.pdf", loader_cls=PyPDFLoader)
-    documents = loader.load() # load the pdf and extract text using PyPDFLoader
+
+    loader_mapping = {
+        ".pdf": PyPDFLoader,
+        ".txt": TextLoader,
+        ".docx": UnstructuredWordDocumentLoader,
+        ".pptx": UnstructuredPowerPointLoader
+    }
+
+    all_documents = []
+    for ext, loader_cls in loader_mapping.items():
+        pattern = os.path.join(course_dir, f"**/*{ext}")
+        for file_path in glob.glob(pattern, recursive=True):
+            try:
+                loader = loader_cls(file_path)
+                docs = loader.load()
+                all_documents.extend(docs)
+            except Exception as e:
+                print(f"Failed to load {file_path}: {e}")
+        
+        if not all_documents:
+            print("No supported documents found.")
+            return
 
     # Splitting the text into chunks
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200) # Divide into 1000 char chunks w/ 200 char overlap to retain context across chunks
-    texts = text_splitter.split_documents(documents) # contains the document chunks
+    texts = text_splitter.split_documents(all_documents) # contains the document chunks
     print(f"Number of text chunks: {len(texts)}")
 
     # FAISS Vector Store Creation

--- a/docker-image/src/app.py
+++ b/docker-image/src/app.py
@@ -626,15 +626,15 @@ def instructor_files(module_id):
                 fobj.stream.seek(0)
             except Exception as e:
                 app.logger.error(f"Transcription failed: {e}")
-        data = fobj.read()
+        file_bytes = fobj.read()
         new_file = create_file(
             db,
             module_id=module_id,
             title=request.form.get('title', fobj.filename),
             filename=fobj.filename,
             file_type=fobj.mimetype,
-            file_size=len(data),
-            file_data=data
+            file_size=len(file_bytes),
+            file_data=file_bytes
         )
         if transcription is not None:
             update_file(db, new_file.id, transcription=transcription)
@@ -644,9 +644,12 @@ def instructor_files(module_id):
         tmp_idx_dir = os.path.join(tmp_root, "faiss_index")
         os.makedirs(tmp_idx_dir, exist_ok=True)
 
-        file_bytes = new_file.file_data
-        with open(os.path.join(tmp_idx_dir, "output.pdf"), "wb") as pdf:
-            pdf.write(file_bytes)
+        # Extract file extension
+        ext = os.path.splittext(fobj.filename)[1]
+
+        input_filename = f"uploaded{ext}"
+        with open(os.path.join(tmp_idx_dir, input_filename), "wb") as out:
+            out.write(file_bytes)
 
         # Generate FAISS index files
         create_database(tmp_idx_dir)

--- a/docker-image/src/app.py
+++ b/docker-image/src/app.py
@@ -638,18 +638,22 @@ def instructor_files(module_id):
         )
         if transcription is not None:
             update_file(db, new_file.id, transcription=transcription)
-
+        
         # Create temporary directory and write uploaded file
         tmp_root = tempfile.mkdtemp(prefix=f"faiss_tmp_{new_file.id}_")
         tmp_idx_dir = os.path.join(tmp_root, "faiss_index")
         os.makedirs(tmp_idx_dir, exist_ok=True)
-
-        # Extract file extension
-        ext = os.path.splittext(fobj.filename)[1]
-
-        input_filename = f"uploaded{ext}"
-        with open(os.path.join(tmp_idx_dir, input_filename), "wb") as out:
-            out.write(file_bytes)
+        # If transcription, use transcribed text, otherwise use uploaded file
+        if transcription is not None:
+            input_filename = "transcription.txt"
+            with open(os.path.join(tmp_idx_dir, input_filename), "w", encoding="utf-8") as txt:
+                txt.write(transcription)
+        else:
+            # Extract file extension
+            ext = os.path.splittext(fobj.filename)[1]
+            input_filename = f"uploaded{ext}"
+            with open(os.path.join(tmp_idx_dir, input_filename), "wb") as out:
+                out.write(file_bytes)
 
         # Generate FAISS index files
         create_database(tmp_idx_dir)

--- a/docker-image/src/requirements.txt
+++ b/docker-image/src/requirements.txt
@@ -20,3 +20,6 @@ textract
 tiktoken
 pgvector
 pytest
+unstructured[pdf, docx, pptx]
+python-docx
+python-pptx


### PR DESCRIPTION
Changes made to fix the indexing workaround.  FAISS db generation should now work with pdf, txt, docx, and pptx files now.  Transcriptions get converted to .txt when generating the db.